### PR TITLE
🐞 fix(findNode): unexpected usage for node.descendants

### DIFF
--- a/src/find-node.ts
+++ b/src/find-node.ts
@@ -8,25 +8,24 @@ type FoundNode = {
 type Args = {
 	node: Node
 	fieldId: string
+	pos?: number
 }
 export const findTemplateFieldNode = ({
 	node,
 	fieldId,
+	pos = 0
 }: Args): FoundNode | undefined => {
-	let foundNode: FoundNode | undefined = undefined
 
-	node.descendants((innerNode, pos) => {
-		if (innerNode.attrs.id === fieldId) {
-			foundNode = { node: innerNode, pos }
+	for (let i = 0; i < node.childCount; i++) {
+		const child = node.child(i)
+		if (child.type.name === 'repro-extension' && child.attrs.id === fieldId) {
+			return { node: child, pos }
 		} else {
-			const innerFoundNode = findTemplateFieldNode({
-				node: innerNode,
-				fieldId,
-			})
-			if (innerFoundNode) foundNode = innerFoundNode
+			const foundNode = findTemplateFieldNode({ node: child, fieldId, pos: pos + 1 })
+			if (foundNode) {
+				return foundNode
+			}
 		}
-		if (foundNode) return false
-	})
-
-	return foundNode
+		pos += child.nodeSize
+	}
 }

--- a/src/remirror-editor.tsx
+++ b/src/remirror-editor.tsx
@@ -14,9 +14,9 @@ import {
 } from '@remirror/react'
 import { ComponentType, forwardRef, useImperativeHandle } from 'react'
 
-const ReproExtensionInitialContent = `<span data-field-id="initial-id"></span>`
+const ReproExtensionInitialContent = `<p><span data-field-id="initial-id"></span><span data-field-id="initial-id"></span></p><p><span data-field-id="initial-id"></span><span data-field-id="initial-id"></span></p>`
 
-export class ReproExtension extends NodeExtension {
+	export class ReproExtension extends NodeExtension {
 	get name() {
 		return 'repro-extension' as const
 	}


### PR DESCRIPTION
`node.descendants` recursively traverses all the child nodes of the given `node`, with `pos` starting from 0. Since you are calling it recursively, each new parent will also start from 0. Moreover, this method will continue traversing to the end of the current parent even when `return false` is used. Therefore, it would be more efficient to write a custom `for` loop instead.